### PR TITLE
Tie each WasmMsg to caller filename:fileno

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = { version = "1.0.51"}
+backtrace = "0.3"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 log = "0.4.0"

--- a/src/profilers/profiler.rs
+++ b/src/profilers/profiler.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use backtrace::Backtrace;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -16,8 +17,9 @@ pub trait Profiler {
         contract: String,
         op_name: String,
         op_type: CommandType,
-        input_json: &Value,
         output_json: &Value,
+        backtrace: &Backtrace,
+        msg_idx: usize,
     ) -> Result<()>;
     fn report(&self) -> Result<Report>;
 }


### PR DESCRIPTION
This allows us to show which WasmMsg cost how much gas in the source file.

Now devs can very easily find which message cost more gas in a diff. This even allows the cosm-orc github action to comment on a specific line for offending gas usages! 