### PR TITLE
CosmOrc api unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 log = "0.4.0"
 config = { version = "0.13.1", features = ["yaml"] }
+mockall = "0.11.2"
+mockall_double = "0.3.0"
 
 # NOTE: I need to use an older version of cosmrs until I can fix the transitive dependency collision error
 cosmrs = { version = "0.7.1", features = ["rpc", "cosmwasm"] }
@@ -29,5 +31,6 @@ tokio = { version = "1.20.1", features = ["full"] }
 prost = "0.10.4"
 
 [dev-dependencies]
+assert_matches = "1.5"
 cw20-base = "0.13"
 cw20 = "0.13"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,7 @@
-pub(crate) mod cosm_client;
-
 pub mod error;
+
+#[allow(dead_code)]
+pub(crate) mod cosm_client;
 
 pub use self::cosm_client::TendermintRes;
 pub use cosmrs::tendermint::abci::Code;

--- a/src/orchestrator/cosm_orc.rs
+++ b/src/orchestrator/cosm_orc.rs
@@ -340,7 +340,7 @@ mod tests {
                 eq(payload),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {
@@ -399,7 +399,7 @@ mod tests {
                 eq(payload),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {
@@ -467,7 +467,7 @@ mod tests {
                 eq(payload),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {
@@ -621,7 +621,7 @@ mod tests {
                 eq(payload.clone()),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {
@@ -645,7 +645,7 @@ mod tests {
                 eq(payload),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {
@@ -719,7 +719,7 @@ mod tests {
                 eq(payload.clone()),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {
@@ -743,7 +743,7 @@ mod tests {
                 eq(payload),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {
@@ -818,7 +818,7 @@ mod tests {
                 eq(payload.clone()),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {
@@ -842,7 +842,7 @@ mod tests {
                 eq(payload),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {
@@ -1009,7 +1009,7 @@ mod tests {
                 eq(payload.clone()),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {
@@ -1100,7 +1100,7 @@ mod tests {
                 eq(payload.clone()),
                 function(move |k: &SigningKey| {
                     let Key::Mnemonic(phrase) = &k.key;
-                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                    k.name == "test" && phrase == "word1 word2"
                 }),
             )
             .returning(|_, _, _| {

--- a/src/orchestrator/cosm_orc.rs
+++ b/src/orchestrator/cosm_orc.rs
@@ -520,7 +520,6 @@ mod tests {
         let report: HashMap<String, HashMap<String, GasReport>> =
             serde_json::from_slice(&reports[0].json_data).unwrap();
         assert_eq!(report.keys().len(), 1);
-        assert_eq!(report.keys().next().unwrap(), &"cw_test".to_string());
         assert_eq!(report.get("cw_test").unwrap().keys().len(), 1);
 
         let r = report
@@ -893,7 +892,6 @@ mod tests {
         let report: HashMap<String, HashMap<String, GasReport>> =
             serde_json::from_slice(&reports[0].json_data).unwrap();
         assert_eq!(report.keys().len(), 1);
-        assert_eq!(report.keys().next().unwrap(), &"cw_test".to_string());
         assert_eq!(report.get("cw_test").unwrap().keys().len(), 1);
 
         let r = report
@@ -918,7 +916,6 @@ mod tests {
         let report: HashMap<String, HashMap<String, GasReport>> =
             serde_json::from_slice(&reports[0].json_data).unwrap();
         assert_eq!(report.keys().len(), 1);
-        assert_eq!(report.keys().next().unwrap(), &"cw_test".to_string());
         assert_eq!(report.get("cw_test").unwrap().keys().len(), 2);
 
         let r = report

--- a/src/orchestrator/cosm_orc.rs
+++ b/src/orchestrator/cosm_orc.rs
@@ -1,4 +1,5 @@
 use log::{debug, info};
+use mockall_double::double;
 use serde::Serialize;
 use std::ffi::OsStr;
 use std::fmt::{self, Debug};
@@ -7,12 +8,15 @@ use std::panic::Location;
 use std::path::Path;
 
 use super::error::{ProcessError, ReportError, StoreError};
-use crate::client::cosm_client::{tokio_block, CosmClient, TendermintRes};
+use crate::client::cosm_client::{tokio_block, TendermintRes};
 use crate::client::error::ClientError;
 use crate::config::cfg::Config;
 use crate::config::key::SigningKey;
 use crate::orchestrator::deploy::ContractMap;
 use crate::profilers::profiler::{CommandType, Profiler, Report};
+
+#[double]
+use crate::client::cosm_client::CosmClient;
 
 /// Stores cosmwasm contracts and executes their messages against the configured chain.
 pub struct CosmOrc {
@@ -104,7 +108,7 @@ impl CosmOrc {
     /// * `contract_name` - Stored smart contract name for the corresponding `msg`.
     /// * `msg` - InstantiateMsg that `contract_name` supports.
     /// * `op_name` - Human readable operation name for profiling bookkeeping usage.
-    /// * `key` - SigningKey used to sign the tx
+    /// * `key` - SigningKey used to sign the tx.
     ///
     /// # Errors
     /// * If `contract_name` has not been configured in `Config::code_ids` or stored through
@@ -253,5 +257,936 @@ impl CosmOrc {
         }
 
         Ok(reports)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CosmOrc;
+    use crate::{
+        client::{
+            cosm_client::{ExecResponse, InstantiateResponse, QueryResponse},
+            error::ClientError,
+            TendermintRes,
+        },
+        config::key::{Key, SigningKey},
+        orchestrator::{
+            deploy::ContractMap,
+            error::{ContractMapError, ProcessError, StoreError},
+        },
+        profilers::gas_profiler::{GasProfiler, GasReport},
+    };
+    use assert_matches::assert_matches;
+    use cosmrs::tendermint::abci::Code;
+    use mockall::predicate::{eq, function};
+    use mockall_double::double;
+    use serde::Serialize;
+    use std::collections::HashMap;
+
+    #[double]
+    use crate::client::cosm_client::CosmClient;
+
+    #[derive(Serialize)]
+    pub struct TestMsg {}
+
+    #[test]
+    fn instantiate_not_stored() {
+        let code_ids = HashMap::new();
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: CosmClient::default(),
+            profilers: vec![],
+        };
+
+        let res = cosm_orc.instantiate("cw_not_stored", "i_test", &TestMsg {}, &key);
+
+        assert_matches!(
+            res.unwrap_err(),
+            ProcessError::ContractMapError(e) if e == ContractMapError::NotStored{name: "cw_not_stored".to_string()}
+        );
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_not_stored").unwrap_err(),
+            ContractMapError::NotStored {
+                name: "cw_not_stored".to_string()
+            }
+        );
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn instantiate_cosmossdk_error() {
+        let code_ids = HashMap::from([("cw_test".to_string(), 1337)]);
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let msg = &TestMsg {};
+        let payload = serde_json::to_vec(msg).unwrap();
+
+        let mut mock_client = CosmClient::default();
+
+        mock_client
+            .expect_instantiate()
+            .with(
+                eq(1337),
+                eq(payload),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Err(ClientError::CosmosSdk {
+                    res: TendermintRes {
+                        code: Code::Err(10),
+                        data: Some(vec![]),
+                        log: "error log".to_string(),
+                        gas_used: 1001,
+                        gas_wanted: 1002,
+                    },
+                })
+            })
+            .times(1);
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: mock_client,
+            profilers: vec![],
+        };
+
+        let res = cosm_orc.instantiate("cw_test", "i_test", msg, &key);
+
+        assert_matches!(
+            res.unwrap_err(),
+            ProcessError::ClientError(ClientError::CosmosSdk { .. })
+        );
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_test".to_string()
+            }
+        );
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn instantiate() {
+        let code_ids = HashMap::from([("cw_test".to_string(), 1337)]);
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let msg = &TestMsg {};
+        let payload = serde_json::to_vec(msg).unwrap();
+
+        let mut mock_client = CosmClient::default();
+
+        mock_client
+            .expect_instantiate()
+            .with(
+                eq(1337),
+                eq(payload),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Ok(InstantiateResponse {
+                    address: "cosmos_contract_addr".to_string(),
+                    res: TendermintRes {
+                        code: Code::Ok,
+                        data: Some(vec![]),
+                        log: "".to_string(),
+                        gas_used: 100,
+                        gas_wanted: 101,
+                    },
+                })
+            })
+            .times(1);
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: mock_client,
+            profilers: vec![],
+        };
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_test".to_string()
+            }
+        );
+
+        let res = cosm_orc
+            .instantiate("cw_test", "i_test", msg, &key)
+            .unwrap();
+
+        assert_eq!(res.code, Code::Ok);
+        assert_eq!(res.data, Some(vec![]));
+        assert_eq!(res.log, "".to_string());
+        assert_eq!(res.gas_used, 100);
+        assert_eq!(res.gas_wanted, 101);
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap(),
+            "cosmos_contract_addr".to_string()
+        );
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn instantiate_with_profiler() {
+        let code_ids = HashMap::from([("cw_test".to_string(), 1337)]);
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let msg = &TestMsg {};
+        let payload = serde_json::to_vec(msg).unwrap();
+
+        let mut mock_client = CosmClient::default();
+
+        mock_client
+            .expect_instantiate()
+            .with(
+                eq(1337),
+                eq(payload),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Ok(InstantiateResponse {
+                    address: "cosmos_contract_addr".to_string(),
+                    res: TendermintRes {
+                        code: Code::Ok,
+                        data: Some(vec![]),
+                        log: "".to_string(),
+                        gas_used: 100,
+                        gas_wanted: 101,
+                    },
+                })
+            })
+            .times(1);
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: mock_client,
+            profilers: vec![],
+        }
+        .add_profiler(Box::new(GasProfiler::new()));
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_test".to_string()
+            }
+        );
+
+        let res = cosm_orc
+            .instantiate("cw_test", "i_test", msg, &key)
+            .unwrap();
+
+        assert_eq!(res.code, Code::Ok);
+        assert_eq!(res.data, Some(vec![]));
+        assert_eq!(res.log, "".to_string());
+        assert_eq!(res.gas_used, 100);
+        assert_eq!(res.gas_wanted, 101);
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap(),
+            "cosmos_contract_addr".to_string()
+        );
+
+        let reports = cosm_orc.profiler_reports().unwrap();
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].name, "gas-profiler".to_string());
+
+        let report: HashMap<String, HashMap<String, GasReport>> =
+            serde_json::from_slice(&reports[0].json_data).unwrap();
+        assert_eq!(report.keys().len(), 1);
+        assert_eq!(report.keys().next().unwrap(), &"cw_test".to_string());
+        assert_eq!(report.get("cw_test").unwrap().keys().len(), 1);
+
+        let r = report
+            .get("cw_test")
+            .unwrap()
+            .get("Instantiate__i_test")
+            .unwrap();
+        assert_eq!(r.gas_used, 100);
+        assert_eq!(r.gas_wanted, 101);
+    }
+
+    #[test]
+    fn execute_not_stored() {
+        let code_ids = HashMap::new();
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: CosmClient::default(),
+            profilers: vec![],
+        };
+
+        let res = cosm_orc.execute("cw_not_stored", "e_test", &TestMsg {}, &key);
+
+        assert_matches!(
+            res.unwrap_err(),
+            ProcessError::ContractMapError(e) if e == ContractMapError::NotStored{name: "cw_not_stored".to_string()}
+        );
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_not_stored").unwrap_err(),
+            ContractMapError::NotStored {
+                name: "cw_not_stored".to_string()
+            }
+        );
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn execute_not_initialized() {
+        let code_ids = HashMap::from([("cw_not_init".to_string(), 1337)]);
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: CosmClient::default(),
+            profilers: vec![],
+        };
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_not_init").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_not_init".to_string()
+            }
+        );
+
+        let res = cosm_orc.execute("cw_not_init", "e_test", &TestMsg {}, &key);
+
+        assert_matches!(
+            res.unwrap_err(),
+            ProcessError::ContractMapError(e) if e == ContractMapError::NotDeployed{name: "cw_not_init".to_string()}
+        );
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_not_init").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_not_init".to_string()
+            }
+        );
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn execute_cosmossdk_error() {
+        let code_ids = HashMap::from([("cw_test".to_string(), 1337)]);
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let msg = &TestMsg {};
+        let payload = serde_json::to_vec(msg).unwrap();
+
+        let mut mock_client = CosmClient::default();
+
+        mock_client
+            .expect_instantiate()
+            .with(
+                eq(1337),
+                eq(payload.clone()),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Ok(InstantiateResponse {
+                    address: "cosmos_contract_addr".to_string(),
+                    res: TendermintRes {
+                        code: Code::Ok,
+                        data: Some(vec![]),
+                        log: "".to_string(),
+                        gas_used: 100,
+                        gas_wanted: 101,
+                    },
+                })
+            })
+            .times(1);
+
+        mock_client
+            .expect_execute()
+            .with(
+                eq("cosmos_contract_addr".to_string()),
+                eq(payload),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Err(ClientError::CosmosSdk {
+                    res: TendermintRes {
+                        code: Code::Err(10),
+                        data: Some(vec![]),
+                        log: "error log".to_string(),
+                        gas_used: 1001,
+                        gas_wanted: 1002,
+                    },
+                })
+            })
+            .times(1);
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: mock_client,
+            profilers: vec![],
+        };
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_test".to_string()
+            }
+        );
+
+        let res = cosm_orc
+            .instantiate("cw_test", "i_test", msg, &key)
+            .unwrap();
+
+        assert_eq!(res.code, Code::Ok);
+        assert_eq!(res.data, Some(vec![]));
+        assert_eq!(res.log, "".to_string());
+        assert_eq!(res.gas_used, 100);
+        assert_eq!(res.gas_wanted, 101);
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap(),
+            "cosmos_contract_addr".to_string()
+        );
+
+        let res = cosm_orc.execute("cw_test", "e_test", msg, &key);
+
+        assert_matches!(
+            res.unwrap_err(),
+            ProcessError::ClientError(ClientError::CosmosSdk { .. })
+        );
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn execute() {
+        let code_ids = HashMap::from([("cw_test".to_string(), 1337)]);
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let msg = &TestMsg {};
+        let payload = serde_json::to_vec(msg).unwrap();
+
+        let mut mock_client = CosmClient::default();
+
+        mock_client
+            .expect_instantiate()
+            .with(
+                eq(1337),
+                eq(payload.clone()),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Ok(InstantiateResponse {
+                    address: "cosmos_contract_addr".to_string(),
+                    res: TendermintRes {
+                        code: Code::Ok,
+                        data: Some(vec![]),
+                        log: "".to_string(),
+                        gas_used: 100,
+                        gas_wanted: 101,
+                    },
+                })
+            })
+            .times(1);
+
+        mock_client
+            .expect_execute()
+            .with(
+                eq("cosmos_contract_addr".to_string()),
+                eq(payload),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Ok(ExecResponse {
+                    res: TendermintRes {
+                        code: Code::Ok,
+                        data: Some(vec![]),
+                        log: "log".to_string(),
+                        gas_used: 2001,
+                        gas_wanted: 2002,
+                    },
+                })
+            })
+            .times(1);
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: mock_client,
+            profilers: vec![],
+        };
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_test".to_string()
+            }
+        );
+
+        let res = cosm_orc
+            .instantiate("cw_test", "i_test", msg, &key)
+            .unwrap();
+
+        assert_eq!(res.code, Code::Ok);
+        assert_eq!(res.data, Some(vec![]));
+        assert_eq!(res.log, "".to_string());
+        assert_eq!(res.gas_used, 100);
+        assert_eq!(res.gas_wanted, 101);
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap(),
+            "cosmos_contract_addr".to_string()
+        );
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+
+        let res = cosm_orc.execute("cw_test", "e_test", msg, &key).unwrap();
+        assert_eq!(res.code, Code::Ok);
+        assert_eq!(res.data, Some(vec![]));
+        assert_eq!(res.log, "log".to_string());
+        assert_eq!(res.gas_used, 2001);
+        assert_eq!(res.gas_wanted, 2002);
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn execute_with_profiler() {
+        let code_ids = HashMap::from([("cw_test".to_string(), 1337)]);
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let msg = &TestMsg {};
+        let payload = serde_json::to_vec(msg).unwrap();
+
+        let mut mock_client = CosmClient::default();
+
+        mock_client
+            .expect_instantiate()
+            .with(
+                eq(1337),
+                eq(payload.clone()),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Ok(InstantiateResponse {
+                    address: "cosmos_contract_addr".to_string(),
+                    res: TendermintRes {
+                        code: Code::Ok,
+                        data: Some(vec![]),
+                        log: "".to_string(),
+                        gas_used: 100,
+                        gas_wanted: 101,
+                    },
+                })
+            })
+            .times(1);
+
+        mock_client
+            .expect_execute()
+            .with(
+                eq("cosmos_contract_addr".to_string()),
+                eq(payload),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Ok(ExecResponse {
+                    res: TendermintRes {
+                        code: Code::Ok,
+                        data: Some(vec![]),
+                        log: "log".to_string(),
+                        gas_used: 2001,
+                        gas_wanted: 2002,
+                    },
+                })
+            })
+            .times(1);
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: mock_client,
+            profilers: vec![Box::new(GasProfiler::new())],
+        };
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_test".to_string()
+            }
+        );
+
+        let res = cosm_orc
+            .instantiate("cw_test", "i_test", msg, &key)
+            .unwrap();
+
+        assert_eq!(res.code, Code::Ok);
+        assert_eq!(res.data, Some(vec![]));
+        assert_eq!(res.log, "".to_string());
+        assert_eq!(res.gas_used, 100);
+        assert_eq!(res.gas_wanted, 101);
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap(),
+            "cosmos_contract_addr".to_string()
+        );
+
+        let reports = cosm_orc.profiler_reports().unwrap();
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].name, "gas-profiler".to_string());
+
+        let report: HashMap<String, HashMap<String, GasReport>> =
+            serde_json::from_slice(&reports[0].json_data).unwrap();
+        assert_eq!(report.keys().len(), 1);
+        assert_eq!(report.keys().next().unwrap(), &"cw_test".to_string());
+        assert_eq!(report.get("cw_test").unwrap().keys().len(), 1);
+
+        let r = report
+            .get("cw_test")
+            .unwrap()
+            .get("Instantiate__i_test")
+            .unwrap();
+        assert_eq!(r.gas_used, 100);
+        assert_eq!(r.gas_wanted, 101);
+
+        let res = cosm_orc.execute("cw_test", "e_test", msg, &key).unwrap();
+        assert_eq!(res.code, Code::Ok);
+        assert_eq!(res.data, Some(vec![]));
+        assert_eq!(res.log, "log".to_string());
+        assert_eq!(res.gas_used, 2001);
+        assert_eq!(res.gas_wanted, 2002);
+
+        let reports = cosm_orc.profiler_reports().unwrap();
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].name, "gas-profiler".to_string());
+
+        let report: HashMap<String, HashMap<String, GasReport>> =
+            serde_json::from_slice(&reports[0].json_data).unwrap();
+        assert_eq!(report.keys().len(), 1);
+        assert_eq!(report.keys().next().unwrap(), &"cw_test".to_string());
+        assert_eq!(report.get("cw_test").unwrap().keys().len(), 2);
+
+        let r = report
+            .get("cw_test")
+            .unwrap()
+            .get("Execute__e_test")
+            .unwrap();
+        assert_eq!(r.gas_used, 2001);
+        assert_eq!(r.gas_wanted, 2002);
+    }
+
+    #[test]
+    fn query_not_stored() {
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&HashMap::new()),
+            client: CosmClient::default(),
+            profilers: vec![],
+        };
+
+        let res = cosm_orc.query("cw_not_stored", "q_test", &TestMsg {});
+
+        assert_matches!(
+            res.unwrap_err(),
+            ProcessError::ContractMapError(e) if e == ContractMapError::NotStored{name: "cw_not_stored".to_string()}
+        );
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_not_stored").unwrap_err(),
+            ContractMapError::NotStored {
+                name: "cw_not_stored".to_string()
+            }
+        );
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn query_not_initialized() {
+        let code_ids = HashMap::from([("cw_not_init".to_string(), 1337)]);
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: CosmClient::default(),
+            profilers: vec![],
+        };
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_not_init").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_not_init".to_string()
+            }
+        );
+
+        let res = cosm_orc.query("cw_not_init", "q_test", &TestMsg {});
+
+        assert_matches!(
+            res.unwrap_err(),
+            ProcessError::ContractMapError(e) if e == ContractMapError::NotDeployed{name: "cw_not_init".to_string()}
+        );
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_not_init").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_not_init".to_string()
+            }
+        );
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn query_cosmossdk_error() {
+        let code_ids = HashMap::from([("cw_test".to_string(), 1337)]);
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let msg = &TestMsg {};
+        let payload = serde_json::to_vec(msg).unwrap();
+
+        let mut mock_client = CosmClient::default();
+
+        mock_client
+            .expect_instantiate()
+            .with(
+                eq(1337),
+                eq(payload.clone()),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Ok(InstantiateResponse {
+                    address: "cosmos_contract_addr".to_string(),
+                    res: TendermintRes {
+                        code: Code::Ok,
+                        data: Some(vec![]),
+                        log: "".to_string(),
+                        gas_used: 100,
+                        gas_wanted: 101,
+                    },
+                })
+            })
+            .times(1);
+
+        mock_client
+            .expect_query()
+            .with(eq("cosmos_contract_addr".to_string()), eq(payload))
+            .returning(|_, _| {
+                Err(ClientError::CosmosSdk {
+                    res: TendermintRes {
+                        code: Code::Err(10),
+                        data: Some(vec![]),
+                        log: "error log".to_string(),
+                        gas_used: 1001,
+                        gas_wanted: 1002,
+                    },
+                })
+            })
+            .times(1);
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: mock_client,
+            profilers: vec![],
+        };
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_test".to_string()
+            }
+        );
+
+        let res = cosm_orc
+            .instantiate("cw_test", "i_test", msg, &key)
+            .unwrap();
+
+        assert_eq!(res.code, Code::Ok);
+        assert_eq!(res.data, Some(vec![]));
+        assert_eq!(res.log, "".to_string());
+        assert_eq!(res.gas_used, 100);
+        assert_eq!(res.gas_wanted, 101);
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap(),
+            "cosmos_contract_addr".to_string()
+        );
+
+        let res = cosm_orc.query("cw_test", "q_test", msg);
+
+        assert_matches!(
+            res.unwrap_err(),
+            ProcessError::ClientError(ClientError::CosmosSdk { .. })
+        );
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn query() {
+        let code_ids = HashMap::from([("cw_test".to_string(), 1337)]);
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let msg = &TestMsg {};
+        let payload = serde_json::to_vec(msg).unwrap();
+
+        let mut mock_client = CosmClient::default();
+
+        mock_client
+            .expect_instantiate()
+            .with(
+                eq(1337),
+                eq(payload.clone()),
+                function(move |k: &SigningKey| {
+                    let Key::Mnemonic(phrase) = &k.key;
+                    k.name == "test".to_string() && phrase == &"word1 word2".to_string()
+                }),
+            )
+            .returning(|_, _, _| {
+                Ok(InstantiateResponse {
+                    address: "cosmos_contract_addr".to_string(),
+                    res: TendermintRes {
+                        code: Code::Ok,
+                        data: Some(vec![]),
+                        log: "".to_string(),
+                        gas_used: 100,
+                        gas_wanted: 101,
+                    },
+                })
+            })
+            .times(1);
+
+        mock_client
+            .expect_query()
+            .with(eq("cosmos_contract_addr".to_string()), eq(payload))
+            .returning(|_, _| {
+                Ok(QueryResponse {
+                    res: TendermintRes {
+                        code: Code::Ok,
+                        data: Some(vec![]),
+                        log: "log".to_string(),
+                        gas_used: 2001,
+                        gas_wanted: 2002,
+                    },
+                })
+            })
+            .times(1);
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: mock_client,
+            profilers: vec![],
+        };
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap_err(),
+            ContractMapError::NotDeployed {
+                name: "cw_test".to_string()
+            }
+        );
+
+        let res = cosm_orc
+            .instantiate("cw_test", "i_test", msg, &key)
+            .unwrap();
+
+        assert_eq!(res.code, Code::Ok);
+        assert_eq!(res.data, Some(vec![]));
+        assert_eq!(res.log, "".to_string());
+        assert_eq!(res.gas_used, 100);
+        assert_eq!(res.gas_wanted, 101);
+
+        assert_eq!(
+            cosm_orc.contract_map.address("cw_test").unwrap(),
+            "cosmos_contract_addr".to_string()
+        );
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+
+        let res = cosm_orc.query("cw_test", "q_test", msg).unwrap();
+        assert_eq!(res.code, Code::Ok);
+        assert_eq!(res.data, Some(vec![]));
+        assert_eq!(res.log, "log".to_string());
+        assert_eq!(res.gas_used, 2001);
+        assert_eq!(res.gas_wanted, 2002);
+
+        assert_eq!(cosm_orc.profiler_reports().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn store_invalid_wasm_dir() {
+        let code_ids = HashMap::new();
+        let key = SigningKey {
+            name: "test".to_string(),
+            key: Key::Mnemonic("word1 word2".to_string()),
+        };
+
+        let mut cosm_orc = CosmOrc {
+            contract_map: ContractMap::new(&code_ids),
+            client: CosmClient::default(),
+            profilers: vec![],
+        };
+
+        let res = cosm_orc.store_contracts("invalid_dir", &key);
+        assert_matches!(res.unwrap_err(), StoreError::WasmDirRead { .. });
     }
 }

--- a/src/orchestrator/error.rs
+++ b/src/orchestrator/error.rs
@@ -71,7 +71,7 @@ pub enum ReportError {
     ReportError { source: Box<dyn std::error::Error> },
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum ContractMapError {
     #[error("smart contract not stored on chain: {name:?}")]
     NotStored { name: String },

--- a/src/orchestrator/error.rs
+++ b/src/orchestrator/error.rs
@@ -71,7 +71,7 @@ pub enum ReportError {
     ReportError { source: Box<dyn std::error::Error> },
 }
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum ContractMapError {
     #[error("smart contract not stored on chain: {name:?}")]
     NotStored { name: String },

--- a/src/profilers/gas_profiler.rs
+++ b/src/profilers/gas_profiler.rs
@@ -12,12 +12,12 @@ pub struct GasProfiler {
     report: HashMap<String, HashMap<String, GasReport>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct GasReport {
-    gas_wanted: u64,
-    gas_used: u64,
-    file_name: String,
-    line_number: u32,
+    pub gas_wanted: u64,
+    pub gas_used: u64,
+    pub file_name: String,
+    pub line_number: u32,
 }
 
 impl GasProfiler {

--- a/src/profilers/gas_profiler.rs
+++ b/src/profilers/gas_profiler.rs
@@ -12,7 +12,7 @@ pub struct GasProfiler {
     report: HashMap<String, HashMap<String, GasReport>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GasReport {
     pub gas_wanted: u64,
     pub gas_used: u64,


### PR DESCRIPTION
Adds unit testing for CosmOrc public API, mocking CosmClient using `mockall` crate.