### PR TITLE
Use CosmosSDK gRPC endpoint instead of the Tendermint RPC endpoint for gas fee simulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,14 @@ config = { version = "0.13.1", features = ["yaml"] }
 mockall = "0.11.2"
 mockall_double = "0.3.0"
 
-# NOTE: I need to use an older version of cosmrs until I can fix the transitive dependency collision error
+# TODO: Upgrade to the latest version of cosmrs/cosmos-sdk-proto once
+# cw20 / cw20-base are upgraded to a newer version of `signature` crate to fix the dependency collision error
+
 cosmrs = { version = "0.7.1", features = ["rpc", "cosmwasm"] }
 cosmos-sdk-proto = "0.12.0"
 tendermint-rpc = { version = "0.23.7", features= ["http"] }
 tokio = { version = "1.20.1", features = ["full"] }
+tonic = { version = "0.7.0" }
 prost = "0.10.4"
 
 [dev-dependencies]

--- a/example-configs/juno_local.yaml
+++ b/example-configs/juno_local.yaml
@@ -4,6 +4,7 @@ chain_cfg:
   prefix: "juno"
   chain_id: "testing"
   rpc_endpoint: "http://localhost:26657/"
+  grpc_endpoint: "http://localhost:9090/"
   gas_prices: 0.1
   gas_adjustment: 1.5
 

--- a/example-configs/juno_testnet.yaml
+++ b/example-configs/juno_testnet.yaml
@@ -4,6 +4,7 @@ chain_cfg:
   prefix: "juno"
   chain_id: "uni-3"
   rpc_endpoint: "https://rpc.uni.juno.deuslabs.fi:443"
+  grpc_endpoint: "http://juno-testnet-grpc.polkachu.com:26090"
   gas_prices: 0.1
   gas_adjustment: 1.5
 

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -37,6 +37,12 @@ pub enum ClientError {
     CosmosSdk { res: TendermintRes },
 
     #[error(transparent)]
+    GRPCTransport(#[from] tonic::transport::Error),
+
+    #[error(transparent)]
+    GRPC(#[from] tonic::Status),
+
+    #[error(transparent)]
     RPC(#[from] tendermint_rpc::Error),
 }
 

--- a/src/config/cfg.rs
+++ b/src/config/cfg.rs
@@ -19,6 +19,7 @@ pub struct ChainCfg {
     pub prefix: String,
     pub chain_id: String,
     pub rpc_endpoint: String,
+    pub grpc_endpoint: String,
     pub gas_prices: f64,
     pub gas_adjustment: f64,
 }


### PR DESCRIPTION
When storing very large smart contracts we get a Tendermint RPC error on the gas simulation abci_query() call:
```
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32600,
    "message": "Invalid Request",
    "data": "error reading request body: http: request body too large"
  }
}
```

We can avoid this error by using the gRPC endpoint for simulating gas fees.


I don't like using both the Tendermint http RPC endpoint and the Cosmos-SDK gRPC endpoint, so I will try and find a better path forward soon. But this fixes this issue for now.