### PR TITLE
Upgrade cosmos dependencies + Remove prost now that cosmos-sdk-proto is no longer exposing it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,14 @@ config = { version = "0.13.1", features = ["yaml"] }
 cw-optimizoor = { version = "0.7.1", optional = true }
 chain-registry = { version = "0.2.0-rc3", default-features=false }
 
-# TODO: Upgrade to the latest version of cosmrs/cosmos-sdk-proto once
-# cw20 / cw20-base are upgraded to a newer version of `signature` crate to fix the dependency collision error
-
-cosmrs = { version = "0.7.1", features = ["rpc", "cosmwasm"] }
-cosmos-sdk-proto = "0.12.0"
-tendermint-rpc = { version = "0.23.7", features= ["http"], default-features=false }
+cosmrs = { version = "0.9.0", features = ["rpc", "cosmwasm"] }
+cosmos-sdk-proto = "0.14.0"
+tendermint-rpc = { version = "0.23.9", features= ["http"], default-features=false }
 tokio = { version = "1.20.1", features = ["time"] }
-tonic = { version = "0.7.0", default-features=false }
-prost = { version = "0.10.4", default-features=false }
+tonic = { version = "0.8.0", default-features=false }
 
 [dev-dependencies]
 assert_matches = "1.5"
-cw20-base = "0.13"
-cw20 = "0.13"
+cw20-base = "0.15"
+cw20 = "0.15"
 faux = "0.1.7"

--- a/src/client/cosmos.rs
+++ b/src/client/cosmos.rs
@@ -6,6 +6,7 @@ use cosmos_sdk_proto::cosmos::auth::v1beta1::{
 };
 use cosmos_sdk_proto::cosmos::tx::v1beta1::service_client::ServiceClient;
 use cosmos_sdk_proto::cosmos::tx::v1beta1::SimulateRequest;
+use cosmos_sdk_proto::traits::Message;
 use cosmrs::crypto::secp256k1;
 use cosmrs::rpc::endpoint::broadcast::tx_commit::Response;
 use cosmrs::rpc::Client;
@@ -16,7 +17,6 @@ use cosmrs::{
     tx::{self},
 };
 use cosmrs::{AccountId, Any, Coin, Denom};
-use prost::Message;
 use tendermint_rpc::endpoint::abci_query::AbciQuery;
 
 pub async fn send_tx(

--- a/src/client/cosmwasm.rs
+++ b/src/client/cosmwasm.rs
@@ -1,13 +1,13 @@
 use cosmos_sdk_proto::cosmwasm::wasm::v1::{
     QuerySmartContractStateRequest, QuerySmartContractStateResponse,
 };
+use cosmos_sdk_proto::traits::Message;
 use cosmrs::cosmwasm::{MsgExecuteContract, MsgInstantiateContract, MsgMigrateContract};
 use cosmrs::crypto::secp256k1;
 use cosmrs::rpc::Client;
 use cosmrs::tendermint::abci::tag::Key;
 use cosmrs::tx::Msg;
 use cosmrs::{cosmwasm::MsgStoreCode, rpc::HttpClient};
-use prost::Message;
 use std::str::FromStr;
 use std::time::Duration;
 use tokio::time;

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,5 +1,5 @@
+use cosmos_sdk_proto::prost::{DecodeError, EncodeError};
 use cosmrs::ErrorReport;
-use prost::{DecodeError, EncodeError};
 use thiserror::Error;
 
 use super::chain_res::ChainResponse;


### PR DESCRIPTION
Before we were running into collision dependencies on the `signature` crate trying to upgrade, but the latest versions of all of the cosmos crates came into alignment.

Also, its nice that we can delete `prost` as a dep because of: https://github.com/cosmos/cosmos-rust/commit/2f2a89cff7fefb4c24058ad041ad07a058665ab0