### PR TITLE
Remove unused public async functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![cosm-orc on crates.io](https://img.shields.io/crates/v/cosm-orc.svg)](https://crates.io/crates/cosm-orc) [![Docs](https://docs.rs/cosm-orc/badge.svg)](https://docs.rs/cosm-orc)
 
-Rust Cosmwasm smart contract orchestration and gas profiling library.
+Rust Cosmwasm smart contract integration testing and gas profiling library.
 
 Store, instantiate, execute, and query [Cosmwasm](https://github.com/CosmWasm/cosmwasm) smart contracts against a configured [Cosmos](https://github.com/cosmos/cosmos-sdk) based chain. 
 


### PR DESCRIPTION
These weren't being used by anyone, and Im removing them because they were short sighted. Cosm-orc is going to be sync only for now. If we want to make an async api later we should keep the sync / async APIs in separate files / packages to make it easy to use and make it easier to not accidentally block in the async flows.