### PR TITLE
Expose underlying cosm-tome client for situations where integration tests need to easily query chain state

### DIFF
--- a/src/orchestrator/cosm_orc.rs
+++ b/src/orchestrator/cosm_orc.rs
@@ -39,7 +39,7 @@ use super::error::OptimizeError;
 #[derive(Clone)]
 pub struct CosmOrc<C: CosmosClient> {
     pub contract_map: ContractMap,
-    client: CosmTome<C>,
+    pub client: CosmTome<C>,
     gas_profiler: Option<GasProfiler>,
     tx_options: TxOptions,
 }
@@ -503,7 +503,7 @@ impl<C: CosmosClient> CosmOrc<C> {
     }
 }
 
-pub(crate) fn tokio_block<F: Future>(f: F) -> F::Output {
+pub fn tokio_block<F: Future>(f: F) -> F::Output {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()

--- a/src/orchestrator/cosm_orc.rs
+++ b/src/orchestrator/cosm_orc.rs
@@ -151,7 +151,7 @@ impl<C: CosmosClient> CosmOrc<C> {
                     .ok_or(StoreError::InvalidWasmFileName)?;
 
                 // parse out OS architecture if optimizoor was used:
-                let arch_suffix = format!("-{}", ARCH);
+                let arch_suffix = format!("-{ARCH}");
                 if contract.to_string().ends_with(&arch_suffix) {
                     contract = contract.trim_end_matches(&arch_suffix);
                 }

--- a/src/orchestrator/gas_profiler.rs
+++ b/src/orchestrator/gas_profiler.rs
@@ -55,7 +55,7 @@ impl GasProfiler {
 
         let caller_file_name = caller_loc.file().to_string();
         let caller_line_number = caller_loc.line();
-        let op_key = format!("{:?}__{}", op_type, op_name);
+        let op_key = format!("{op_type:?}__{op_name}");
 
         let m = self.report.entry(contract).or_default();
         m.insert(


### PR DESCRIPTION
This was needed by the stargaze integration tests in order to do:
```
 chain.orc.client.bank_query_balance(...)
```

This seems reasonable to expose for easy chain state querying during testing.