### PR TITLE
Add poll_for_n_secs()

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Potential uses:
 * Integration tests
 * Deployments / Bootstrapping environments
 * Gas profiling
+* Realistic adversarial testing
 
 This project is not intended to be used for mainnet.
 


### PR DESCRIPTION
Local system time can differ from block header time, so this can be used to reliably wait n block seconds before some action can be taken in a smart contract.