### PR TITLE
Reexport all of cosm-tome and upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0"
 optimize = ["cw-optimizoor"]
 
 [dependencies]
-cosm-tome = { version = "0.2.0" }
+cosm-tome = { version = "0.2.1" }
 
 thiserror = "1.0.31"
 erased-serde = "0.3"
@@ -29,7 +29,7 @@ tokio = { version = "1.20.1", default-features=false }
 cw-optimizoor = { version = "0.8.0", optional = true }
 
 [dev-dependencies]
-cosm-tome = { version = "0.2.0", features = ["mocks"] }
+cosm-tome = { version = "0.2.1", features = ["mocks"] }
 cosmos-sdk-proto = "0.15.0"
 
 assert_matches = "1.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,3 +158,7 @@
 pub mod orchestrator;
 
 pub mod config;
+
+// re-export all of cosm-tome in case people want to use arbitrary
+// cosmtome types when accessing the underlying `cosm_orc.client`
+pub use cosm_tome;


### PR DESCRIPTION
This allows people to use all of the cosm-tome types from their integration tests without having to add cosm-tome as a dependency themselves.